### PR TITLE
Align backend image and GraphQL client defaults

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,10 +1,15 @@
 # Backend Dockerfile
-FROM node:14
+FROM python:3.11-slim
 
-WORKDIR /usr/src/app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-COPY package*.json ./
-RUN npm install
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
 
-CMD [ "npm", "start" ]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "4000"]
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,2 @@
-flask
-flask_sqlalchemy
-flask_migrate
-flask_cors
+fastapi
+uvicorn[standard]

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -8,7 +8,8 @@ import { router } from './router'
 import { useAuthStore } from './state/auth'
 import './index.css'
 
-const httpLink = createHttpLink({ uri: import.meta.env.VITE_API_URL + '/graphql' })
+const apiUrl = import.meta.env.VITE_API_URL ?? 'http://localhost:4000'
+const httpLink = createHttpLink({ uri: `${apiUrl}/graphql` })
 const authLink = setContext((_, { headers }) => {
   const token = useAuthStore.getState().token
   return { headers: { ...headers, authorization: token ? `Bearer ${token}` : '' } }


### PR DESCRIPTION
## Summary
- switch the backend Dockerfile to a Python 3.11 base that installs the FastAPI stack
- trim the backend requirements to the FastAPI and Uvicorn packages needed by the compose command
- add a localhost fallback for the web Apollo client when VITE_API_URL is not configured

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690ce4924d64832abb9c6a0da10b9781